### PR TITLE
Fix nullmod report binary

### DIFF
--- a/TopmedPipeline/inst/rmd/null_model_report.Rmd
+++ b/TopmedPipeline/inst/rmd/null_model_report.Rmd
@@ -65,7 +65,8 @@ outcome_string <- modelOutcomeString(outcome, inverse_normal = is_invnorm)
 
 ```{r prepare-data}
 dat <- data.frame(sample.id = nullmod$sample.id,
-                  workingY = nullmod$workingY,
+                  # Need as.vector here because sometimes it's a matrix (but not always)
+                  workingY = as.vector(nullmod$workingY),
                   # Need as.vector here because sometimes it's a matrix (but not always)
                   model_outcome = as.vector(nullmod$outcome),
                   fitted.values = nullmod$fitted.values,

--- a/TopmedPipeline/inst/rmd/null_model_report.Rmd
+++ b/TopmedPipeline/inst/rmd/null_model_report.Rmd
@@ -283,6 +283,14 @@ if (show_varcomp) {
 }
 ```
 
+```{r varcomp-table, results = 'asis'}
+if (show_varcomp) {
+  cat("### Variance component estimates\n\n")
+  k <- knitr::kable(vc)
+  print(k)
+}
+```
+
 ```{r variance-adjustment-header, results = 'asis'}
 if (!is.null(group_var)) {
   cat("## Variance adjustment")

--- a/TopmedPipeline/inst/rmd/null_model_report.Rmd
+++ b/TopmedPipeline/inst/rmd/null_model_report.Rmd
@@ -259,20 +259,27 @@ print(p)
 ```
 
 ```{r varcomp-header, results = 'asis'}
+show_varcomp <- FALSE
 if (!is.null(random)){
-  cat("## Variance components")
+  cat("## Variance components\n")
+
+  if (!all(nullmod$zeroFLAG)) {
+    show_varcomp <- TRUE
+  } else {
+    cat("\nAll variance components are estimated to be 0.\n\n")
+  }
 }
 ```
 
 ```{r varcomp}
-if (!is.null(random)) {
+if (show_varcomp) {
   vc <- varCompCI(nullmod, prop = FALSE)
   vc$component <- rownames(vc)
-  p <- ggplot(vc, aes(x = Est, y = component)) +
-    geom_vline(xintercept = 0, color = COLOR_ZERO_LINE) +
-    geom_point() +
-    geom_errorbarh(aes(xmin = `Lower 95`, xmax = `Upper 95`))
-  print(p)
+    p <- ggplot(vc, aes(x = Est, y = component)) +
+      geom_vline(xintercept = 0, color = COLOR_ZERO_LINE) +
+      geom_point() +
+      geom_errorbarh(aes(xmin = `Lower 95`, xmax = `Upper 95`))
+    print(p)
 }
 ```
 

--- a/TopmedPipeline/inst/rmd/null_model_report.Rmd
+++ b/TopmedPipeline/inst/rmd/null_model_report.Rmd
@@ -109,7 +109,7 @@ configTable(config[disp])
 ## Phenotype distributions
 
 ```{r outcome-distribution-plot}
-if (is_binary) {q
+if (is_binary) {
     ggplot(dat, aes(model_outcome)) +
       geom_bar() +
       stat_count(geom="text", aes_string(label="..count..", vjust=-0.5)) +


### PR DESCRIPTION
Fix a couple issues with the null model report when running with binary traits:
* fix data preparation when no random effects were included
* fix crash when all variance components went to zero

Also add a table of variance component estimates to the report.