### PR TITLE
Generate truncated association test plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@ test
 .Rproj.user
 *.Rproj
 R_library
-packrat/*
-.Rprofile
 testdir
 
+# renv files
+renv/*
+renv.lock
+.Rprofile

--- a/R/assoc_plots.R
+++ b/R/assoc_plots.R
@@ -97,7 +97,8 @@ if (truncate) {
       oob = scales::squish,
       limits = c(0, -log10(truncate_pval_threshold)),
       expand = c(0,0)
-    )
+    ) +
+    ylab(expression(paste(-log[10], "(observed P)") ~ " (truncated)"))
   outfile <- gsub(".", "_truncated.", config["out_file_qq"], fixed=TRUE)
   ggsave(outfile, plot=p, width=6, height=6)
 }
@@ -139,7 +140,8 @@ if (truncate) {
       oob = scales::squish,
       limits = c(0, -log10(truncate_pval_threshold)),
       expand = c(0,0)
-    )
+    ) +
+    ylab(expression(-log[10](p) ~ " (truncated)"))
   outfile <- gsub(".", "_truncated.", config["out_file_manh"], fixed=TRUE)
   ggsave(outfile, plot=p, width=10, height=5)
 }

--- a/R/assoc_plots.R
+++ b/R/assoc_plots.R
@@ -61,7 +61,7 @@ if ("stat" %in% names(assoc)) {
     lambda <- calculateLambda(qchisq(assoc$pval, df=1, lower=FALSE), df=1)
 }
 
-# Check if we should truncate the plots.
+# Check if we should also generate truncated plots.
 truncate = any(assoc$pval < truncate_pval_threshold)
 
 ## qq plot

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ config parameter | default value | description
 `thin` | `TRUE` | Logical for whether to thin points in the QQ and manhattan plots.
 `thin_nbins` | `10` | Number of bins to use for thinning.
 `thin_npoints` | `10000` | Number of points in each bin after thinning.
-
+`truncate_pval_threshold` | `1e-10` | Minimum p-value to display in truncated QQ and manhattan plots.
 
 ### Single-variant
 
@@ -276,7 +276,7 @@ config parameter | default value | description
 --- | --- | ---
 `mac_threshold` | `5` | Minimum minor allele count for variants to include in test. Use a higher threshold when outcome is binary.
 `maf_threshold` | `0.001` | Minimum minor allele frequency for variants to include in test. Only used if `mac_threshold` is `NA`.
-`test_type` | `score` | Type of test to perform. If samples are related (mixed model), options are `score` if `binary` is `FALSE`, `score` and `score.spa` if `binary` is `TRUE`. 
+`test_type` | `score` | Type of test to perform. If samples are related (mixed model), options are `score` if `binary` is `FALSE`, `score` and `score.spa` if `binary` is `TRUE`.
 `conditional_variant_file` | `NA` | RData file with data frame of of conditional variants. Columns should include `chromosome` (or `chr`) and `variant.id`. If provided, these variants will be omitted from the association test output.
 `known_hits_file` | `NA` | RData file with data.frame containing columns `chr` and `pos`. If provided, 1 Mb regions surrounding each variant listed will be omitted from the QQ and manhattan plots.
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ config parameter | default value | description
 `thin` | `TRUE` | Logical for whether to thin points in the QQ and manhattan plots.
 `thin_nbins` | `10` | Number of bins to use for thinning.
 `thin_npoints` | `10000` | Number of points in each bin after thinning.
-`truncate_pval_threshold` | `1e-10` | Minimum p-value to display in truncated QQ and manhattan plots.
+`truncate_pval_threshold` | `1e-12` | Minimum p-value to display in truncated QQ and manhattan plots.
 
 ### Single-variant
 


### PR DESCRIPTION
I added some code to `assoc_plots.R` that generates two extra QQ and Manhattan plots plots if any p-values are lower than some threshold (default = 1e-12). These extra plots truncate the y-axis at a given p-value threshold so the behavior of the p-values with more modest p-values can be inspected. (The non-truncated versions of the plots are always created.) The user can change this threshold by adding "truncate_pval_threshold" to the `assoc.py` config file.

To see what happens, you can add "truncate_pval_threshold 0.1" to `assoc_single.py` and then run `assoc.py`.