### PR TITLE
Generate a QQ plot faceted by chromosome

### DIFF
--- a/R/assoc_plots.R
+++ b/R/assoc_plots.R
@@ -87,15 +87,15 @@ if (as.logical(config["thin"])) {
 }
 
 p <- ggplot(dat, aes(-log10(exp), -log10(obs))) +
+    geom_abline(intercept=0, slope=1, color="red") +
     geom_line(aes(-log10(exp), -log10(upper)), color="gray") +
     geom_line(aes(-log10(exp), -log10(lower)), color="gray") +
-    geom_point() +
-    geom_abline(intercept=0, slope=1, color="red") +
     xlab(expression(paste(-log[10], "(expected P)"))) +
     ylab(expression(paste(-log[10], "(observed P)"))) +
     ggtitle(paste("lambda =", format(lambda, digits=4, nsmall=3))) +
     theme_bw() +
-    theme(plot.title = element_text(size = 22))
+    theme(plot.title = element_text(size = 22)) +
+    geom_point()
 ggsave(config["out_file_qq"], plot=p, width=6, height=6)
 
 if (truncate) {

--- a/R/assoc_plots.R
+++ b/R/assoc_plots.R
@@ -109,29 +109,28 @@ if (as.logical(config["thin"])) {
       ungroup()
 }
 
+gg_qq <- list(
+  geom_abline(intercept=0, slope=1, color="red"),
+  geom_line(aes(-log10(exp), -log10(upper)), color="gray"),
+  geom_line(aes(-log10(exp), -log10(lower)), color="gray"),
+  xlab(expression(paste(-log[10], "(expected P)"))),
+  ylab(expression(paste(-log[10], "(observed P)"))),
+  theme_bw()
+)
+
 p <- ggplot(dat, aes(-log10(exp), -log10(obs))) +
-    geom_abline(intercept=0, slope=1, color="red") +
-    geom_line(aes(-log10(exp), -log10(upper)), color="gray") +
-    geom_line(aes(-log10(exp), -log10(lower)), color="gray") +
-    xlab(expression(paste(-log[10], "(expected P)"))) +
-    ylab(expression(paste(-log[10], "(observed P)"))) +
     ggtitle(paste("lambda =", format(lambda, digits=4, nsmall=3))) +
-    theme_bw() +
+    gg_qq +
     theme(plot.title = element_text(size = 22)) +
     geom_point()
 ggsave(config["out_file_qq"], plot=p, width=6, height=6)
 
 # QQ plots by chromosome.
 p_by_chr <- ggplot(dat_by_chr, aes(-log10(exp), -log10(obs))) +
-    geom_abline(intercept=0, slope=1, color="red") +
-    geom_line(aes(-log10(exp), -log10(upper)), color="gray") +
-    geom_line(aes(-log10(exp), -log10(lower)), color="gray") +
-    geom_point(size = 0.5) +
-    xlab(expression(paste(-log[10], "(expected P)"))) +
-    ylab(expression(paste(-log[10], "(observed P)"))) +
+    gg_qq +
     ggtitle(paste("lambda =", format(lambda, digits=4, nsmall=3))) +
-    theme_bw() +
     theme(plot.title = element_text(size = 22)) +
+    geom_point(size = 0.5) +
     facet_wrap(~ chr)
 outfile <- gsub(".", "_bychr.", config["out_file_qq"], fixed=TRUE)
 ggsave(outfile, plot = p_by_chr, width = 10, height = 9)

--- a/R/assoc_plots.R
+++ b/R/assoc_plots.R
@@ -84,7 +84,7 @@ dat <- assoc %>%
   ) %>%
   select(-x)
 
-## qq plot
+## Calculate QQ values separately for each chromosome.
 dat_by_chr <- assoc %>%
   select(
     chr = chr,

--- a/R/assoc_plots.R
+++ b/R/assoc_plots.R
@@ -65,12 +65,19 @@ if ("stat" %in% names(assoc)) {
 truncate = any(assoc$pval < truncate_pval_threshold)
 
 ## qq plot
-n <- nrow(assoc)
-x <- 1:n
-dat <- data.frame(obs=sort(assoc$pval),
-                  exp=x/n,
-                  upper=qbeta(0.025, x, rev(x)),
-                  lower=qbeta(0.975, x, rev(x)))
+dat <- assoc %>%
+  select(
+    obs = pval
+  ) %>%
+  arrange(obs) %>%
+  mutate(
+    x = row_number(),
+    exp = x / n(),
+    upper = qbeta(0.025, x, rev(x)),
+    lower = qbeta(0.975, x, rev(x))
+  ) %>%
+  select(-x)
+
 
 thin.n <- as.integer(config["thin_npoints"])
 thin.bins <- as.integer(config["thin_nbins"])


### PR DESCRIPTION
One analysis showed a peculiar bump in the QQ plot due to a region on a single chromosome. It was helpful to look at separate QQ plots for each chromosome to diagnose where the problem was. This branch adds a new plot: QQ plots faceted by chromosome, where the expected p-values are calculated separately for each chromosome.

One of the new plots added (for VTE data) is located here (on the servers): `/projects/topmed/analyses/VTE/analysts/amstilp/fr8/plots/EA_cond_qq.png`