### PR TITLE
Null model report updates

### DIFF
--- a/R/null_model_report.R
+++ b/R/null_model_report.R
@@ -12,12 +12,16 @@ config <- readConfig(argv$config)
 required <- c()
 optional <- c("family"="gaussian",
               "inverse_normal"=TRUE,
-              "out_prefix"="null_model")
+              "out_prefix"="null_model",
+              "n_categories_boxplot" = 10)
 config <- setConfigDefaults(config, required, optional)
 print(config)
 
 print('rendering report for original null model')
-p <- list(pipeline_version = argv$version)
+p <- list(
+  pipeline_version = argv$version,
+  n_categories_boxplot = config["n_categories_boxplot"]
+)
 outfile <- sprintf("%s_report", config["out_prefix"])
 custom_render_markdown("null_model_report", outfile, parameters = p)
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ config parameter | default value | description
 `conditional_variant_file` | `NA` | RData file with data frame of of conditional variants. Columns should include `chromosome` (or `chr`) and `variant.id`. The alternate allele dosage of these variants will be included as covariates in the analysis.
 `gds_file` | `NA` | GDS file. Include a space to insert chromosome. Required if `conditional_variant_file` is specified.
 `sample_include_file` | `NA` | RData file with vector of sample.id to include.
-`n_categories_boxplot` | `10` | If a covariate has fewer than the specific value, boxplots will be used instead of scatter plots for that covariate in the null model report.
+`n_categories_boxplot` | `10` | If a covariate has fewer than the specified value, boxplots will be used instead of scatter plots for that covariate in the null model report.
 
 
 ### Parameters common to all association tests

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The first step in evalulating relatedness and population structure is to select 
     `out_prefix` | | Prefix for files created by this script.
     `gds_file` | | GDS file with only LD pruned variants, all chromosomes.
 	`full_gds_file` | | GDS file with all variants. Include a space to insert chromosome.
-	`kinship_file` | `NA` | File containing kinship matrix to use for defining the unrelated sample set. Multiple formats are accepted, including RData or GDS from `king.py` or `pcrelate.py`. A sparse Matrix object stored as RData is recommended. 
+	`kinship_file` | `NA` | File containing kinship matrix to use for defining the unrelated sample set. Multiple formats are accepted, including RData or GDS from `king.py` or `pcrelate.py`. A sparse Matrix object stored as RData is recommended.
 	`divergence_file` | `NA` | GDS (recommended) or RData file with kinship coefficients created by `king_robust.py`. Used for ancestry divergence.
 	`kinship_threshold` | `0.04419417` | Minimum kinship estimate to use for assigning relatives (default is `2^(-9/2)` or 3rd degree relatives).
 	`divergence_threshold` | `-0.04419417` | Minimum kinship estimate to use for ancestry divergence (default is `-2^(-9/2)`).
@@ -254,6 +254,7 @@ config parameter | default value | description
 `conditional_variant_file` | `NA` | RData file with data frame of of conditional variants. Columns should include `chromosome` (or `chr`) and `variant.id`. The alternate allele dosage of these variants will be included as covariates in the analysis.
 `gds_file` | `NA` | GDS file. Include a space to insert chromosome. Required if `conditional_variant_file` is specified.
 `sample_include_file` | `NA` | RData file with vector of sample.id to include.
+`n_categories_boxplot` | `10` | If a covariate has fewer than the specific value, boxplots will be used instead of scatter plots for that covariate in the null model report.
 
 
 ### Parameters common to all association tests

--- a/TopmedPipeline.py
+++ b/TopmedPipeline.py
@@ -2,7 +2,7 @@
 from __future__ import division
 """Utility functions for TOPMed pipeline"""
 
-__version__ = "2.8.0"
+__version__ = "2.8.1"
 
 import os
 import sys

--- a/TopmedPipeline/DESCRIPTION
+++ b/TopmedPipeline/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: TopmedPipeline
-Version: 2.8.0
+Version: 2.8.1
 Type: Package
 Title: Utilities for the TOPMed pipeline
 Description: Utilities for the TOPMed pipeline.

--- a/TopmedPipeline/inst/rmd/null_model_report.Rmd
+++ b/TopmedPipeline/inst/rmd/null_model_report.Rmd
@@ -5,6 +5,7 @@ output:
     toc: true
 params:
   invnorm: FALSE
+  n_categories_boxplot: 10
   pipeline_version: 0
 ---
 
@@ -30,6 +31,11 @@ configTable <- function(x) {
 }
 
 COLOR_ZERO_LINE = "grey60"
+n_categories_boxplot = as.numeric(params$n_categories_boxplot)
+```
+
+```{r, results = 'asis'}
+print(n_categories_boxplot)
 ```
 
 ```{r}
@@ -66,7 +72,7 @@ outcome_string <- modelOutcomeString(outcome, inverse_normal = is_invnorm)
 ```{r prepare-data}
 # Display any covariate with < 10 values using boxplots instead of scatterplots.
 for (covar in covars) {
-  if (!is.numeric(annot[[covar]]) || length(unique(annot[[covar]])) < 10) {
+  if (!is.numeric(annot[[covar]]) || length(unique(annot[[covar]])) < n_categories_boxplot) {
     annot[[covar]] <- as.factor(annot[[covar]])
   }
 }

--- a/TopmedPipeline/inst/rmd/null_model_report.Rmd
+++ b/TopmedPipeline/inst/rmd/null_model_report.Rmd
@@ -226,8 +226,10 @@ cat(text)
 ```{r residual-plots, results = "asis"}
 for (x in covars) {
     cat(sprintf("\n\n### %s {.unlisted .unnumbered}\n\n", x))
-    p_out <- ggplot(dat, aes_string(x = x, y = "model_outcome"))
-    p_res <- ggplot(dat, aes_string(x = x, y = "resid.marginal"))
+    p_out <- ggplot(dat, aes_string(x = x, y = "model_outcome")) +
+      ggtitle(outcome_string)
+    p_res <- ggplot(dat, aes_string(x = x, y = "resid.marginal")) +
+      ggtitle(sprintf("%s - residuals", outcome_string))
     if (is.numeric(annot[[x]] )) {
       p_res <- p_res +
         geom_point(alpha = 0.1) +

--- a/TopmedPipeline/inst/rmd/null_model_report.Rmd
+++ b/TopmedPipeline/inst/rmd/null_model_report.Rmd
@@ -157,7 +157,9 @@ for (x in covars) {
         geom_boxplot(varwidth = TRUE) +
         #geom_hline(yintercept = 0, color = COLOR_ZERO_LINE) +
         ## Means by group.
-        stat_summary(fun.y=mean, color="black", shape = 4, geom="point", size = 3)
+        stat_summary(fun.y=mean, color="black", shape = 4, geom="point", size = 3) +
+        # Rotate axis labels.
+        theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust = 1))
     }
     print(p)
 }
@@ -257,7 +259,9 @@ for (x in covars) {
         geom_boxplot(varwidth = TRUE) +
         geom_hline(yintercept = 0, color = COLOR_ZERO_LINE) +
         # Means by group.
-        stat_summary(fun.y=mean, color="black", shape = 4, geom="point", size = 3)
+        stat_summary(fun.y=mean, color="black", shape = 4, geom="point", size = 3) +
+        # Rotate axis labels.
+        theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust = 1))
     }
     print(p)
 }
@@ -347,7 +351,9 @@ if (!is.null(group_var)) {
     geom_boxplot(varwidth = TRUE) +
     theme(axis.text.x = element_text(angle = 90, hjust = 1)) +
     # Means by group.
-    stat_summary(fun.y=mean, color="black", shape = 4, size = 3, geom="point")
+    stat_summary(fun.y=mean, color="black", shape = 4, size = 3, geom="point") +
+    # Rotate axis labels.
+    theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust = 1))
   print(p)
 
   p <- ggplot(dat, aes(x = group, y = Ytilde))
@@ -355,7 +361,9 @@ if (!is.null(group_var)) {
     geom_boxplot(varwidth = TRUE) +
     theme(axis.text.x = element_text(angle = 90, hjust = 1)) +
     geom_hline(yintercept = 0, color = COLOR_ZERO_LINE) +
-    stat_summary(fun.y=mean, color="black", shape = 4, size = 3, geom="point")
+    stat_summary(fun.y=mean, color="black", shape = 4, size = 3, geom="point") +
+    # Rotate axis labels.
+    theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust = 1))
   print(p)
 
 }

--- a/TopmedPipeline/inst/rmd/null_model_report.Rmd
+++ b/TopmedPipeline/inst/rmd/null_model_report.Rmd
@@ -113,7 +113,9 @@ if (as.logical(config["inverse_normal"])) {
 configTable(config[disp])
 ```
 
-## Phenotype distributions
+## Phenotypes
+
+### Distributions
 
 ```{r outcome-distribution-plot}
 if (is_binary) {
@@ -136,6 +138,28 @@ for (x in covars[-grep("^PC[[:digit:]]+", covars)]) {
     } else {
         print(ggplot(annot, aes_string(x)) + geom_bar() + stat_count(geom="text", aes_string(label="..count..", vjust=-0.5)))
     }
+}
+```
+
+### Outcome vs. covariates
+
+```{r outcome-covar-plots}
+for (x in covars) {
+    p <- ggplot(dat, aes_string(x = x, y = "model_outcome"))
+    if (is.numeric(annot[[x]] )) {
+      p <- p +
+        geom_point(alpha = 0.1) +
+        #geom_hline(yintercept = 0, color = COLOR_ZERO_LINE) +
+        geom_smooth(method = 'lm', color = 'red', fill = 'red') +
+        geom_smooth(color = 'blue', linetype = 'dashed', fill = 'blue')
+    } else {
+      p <- p +
+        geom_boxplot(varwidth = TRUE) +
+        #geom_hline(yintercept = 0, color = COLOR_ZERO_LINE) +
+        ## Means by group.
+        stat_summary(fun.y=mean, color="black", shape = 4, geom="point", size = 3)
+    }
+    print(p)
 }
 ```
 

--- a/TopmedPipeline/inst/rmd/null_model_report.Rmd
+++ b/TopmedPipeline/inst/rmd/null_model_report.Rmd
@@ -199,9 +199,10 @@ if (is_binary) {
     "For continuous covariates, plots of marginal residuals vs covariates
     should have a red linear trend line near the `y = 0` line and a blue
     smoothed (cubic regression spline) curve near the y = 0 line. For
-    categorical covariates, the mean of each group should be near 0. A distinct
-    trend could indicate that a more complex term for that covariate is needed
-    (e.g. quadratic, spline, etc.)."
+    categorical covariates, the mean of each group should be near 0. Linear
+    covariates with a small number of unique values are shown using boxplots.
+    A distinct trend could indicate that a more complex term for that covariate
+    is needed (e.g. quadratic, spline, etc.)."
   )
 } else {
   text <- paste(
@@ -209,8 +210,9 @@ if (is_binary) {
     pattern, appearing as random noise. For continuous covariates, the red
     linear trend line and the blue smoothed curve (cubic regression spline)
     should be near the y = 0 line. For categorical covariates, the black cross
-    indicating the group mean should be near 0. A distinct pattern or trend
-    could indicate that a more complex term for that covariate is needed,
+    indicating the group mean should be near 0. Linear covariates with a small
+    number of unique values are shown using boxplots. A distinct pattern or
+    trend could indicate that a more complex term for that covariate is needed,
     (e.g. quadratic, spline, etc.)."
   )
 }
@@ -228,7 +230,7 @@ for (x in covars) {
         geom_smooth(color = 'blue', linetype = 'dashed', fill = 'blue')
     } else {
       p <- p +
-        geom_boxplot() +
+        geom_boxplot(varwidth = TRUE) +
         geom_hline(yintercept = 0, color = COLOR_ZERO_LINE) +
         # Means by group.
         stat_summary(fun.y=mean, color="black", shape = 4, geom="point", size = 3)
@@ -318,7 +320,7 @@ if (!is.null(group_var)) {
 ```{r variance-adjustment-plots}
 if (!is.null(group_var)) {
   p <- ggplot(dat, aes(x = group, y = workingY)) +
-    geom_boxplot() +
+    geom_boxplot(varwidth = TRUE) +
     theme(axis.text.x = element_text(angle = 90, hjust = 1)) +
     # Means by group.
     stat_summary(fun.y=mean, color="black", shape = 4, size = 3, geom="point")
@@ -326,7 +328,7 @@ if (!is.null(group_var)) {
 
   p <- ggplot(dat, aes(x = group, y = Ytilde))
   p <- p +
-    geom_boxplot() +
+    geom_boxplot(varwidth = TRUE) +
     theme(axis.text.x = element_text(angle = 90, hjust = 1)) +
     geom_hline(yintercept = 0, color = COLOR_ZERO_LINE) +
     stat_summary(fun.y=mean, color="black", shape = 4, size = 3, geom="point")

--- a/TopmedPipeline/inst/rmd/null_model_report.Rmd
+++ b/TopmedPipeline/inst/rmd/null_model_report.Rmd
@@ -221,6 +221,7 @@ if (is_binary) {
     (e.g. quadratic, spline, etc.)."
   )
 }
+text <- paste(text, "Plots of the outcome versus each covariate are also shown for reference.")
 cat(text)
 ```
 

--- a/TopmedPipeline/inst/rmd/null_model_report.Rmd
+++ b/TopmedPipeline/inst/rmd/null_model_report.Rmd
@@ -143,30 +143,6 @@ for (x in covars[-grep("^PC[[:digit:]]+", covars)]) {
 }
 ```
 
-### Outcome vs. covariates
-
-```{r outcome-covar-plots}
-for (x in covars) {
-    p <- ggplot(dat, aes_string(x = x, y = "model_outcome"))
-    if (is.numeric(annot[[x]] )) {
-      p <- p +
-        geom_point(alpha = 0.1) +
-        #geom_hline(yintercept = 0, color = COLOR_ZERO_LINE) +
-        geom_smooth(method = 'lm', color = 'red', fill = 'red') +
-        geom_smooth(color = 'blue', linetype = 'dashed', fill = 'blue')
-    } else {
-      p <- p +
-        geom_boxplot(varwidth = TRUE) +
-        #geom_hline(yintercept = 0, color = COLOR_ZERO_LINE) +
-        ## Means by group.
-        stat_summary(fun.y=mean, color="black", shape = 4, geom="point", size = 3) +
-        # Rotate axis labels.
-        theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust = 1))
-    }
-    print(p)
-}
-```
-
 ## Covariate effect size estimates
 
 Covariates are considered to be significant if they have $p < 0.05$ after a Bonferroni correction for the number of fixed effects.
@@ -247,25 +223,40 @@ if (is_binary) {
 cat(text)
 ```
 
-```{r residual-plots}
+```{r residual-plots, results = "asis"}
 for (x in covars) {
-    p <- ggplot(dat, aes_string(x = x, y = "resid.marginal"))
+    cat(sprintf("\n\n### %s {.unlisted .unnumbered}\n\n", x))
+    p_out <- ggplot(dat, aes_string(x = x, y = "model_outcome"))
+    p_res <- ggplot(dat, aes_string(x = x, y = "resid.marginal"))
     if (is.numeric(annot[[x]] )) {
-      p <- p +
+      p_res <- p_res +
         geom_point(alpha = 0.1) +
         geom_hline(yintercept = 0, color = COLOR_ZERO_LINE) +
         geom_smooth(method = 'lm', color = 'red', fill = 'red') +
         geom_smooth(color = 'blue', linetype = 'dashed', fill = 'blue')
+      p_out <- p_out +
+        geom_point(alpha = 0.1) +
+        #geom_hline(yintercept = 0, color = COLOR_ZERO_LINE) +
+        geom_smooth(method = 'lm', color = 'red', fill = 'red') +
+        geom_smooth(color = 'blue', linetype = 'dashed', fill = 'blue')
     } else {
-      p <- p +
+      p_res <- p_res +
         geom_boxplot(varwidth = TRUE) +
         geom_hline(yintercept = 0, color = COLOR_ZERO_LINE) +
         # Means by group.
         stat_summary(fun.y=mean, color="black", shape = 4, geom="point", size = 3) +
         # Rotate axis labels.
         theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust = 1))
+      p_out <- p_out +
+        geom_boxplot(varwidth = TRUE) +
+        #geom_hline(yintercept = 0, color = COLOR_ZERO_LINE) +
+        ## Means by group.
+        stat_summary(fun.y=mean, color="black", shape = 4, geom="point", size = 3) +
+        # Rotate axis labels.
+        theme(axis.text.x = element_text(angle = 30, vjust = 1, hjust = 1))
     }
-    print(p)
+    print(p_out)
+    print(p_res)
 }
 ```
 

--- a/TopmedPipeline/inst/rmd/null_model_report.Rmd
+++ b/TopmedPipeline/inst/rmd/null_model_report.Rmd
@@ -117,16 +117,16 @@ configTable(config[disp])
 
 ```{r outcome-distribution-plot}
 if (is_binary) {
-    ggplot(dat, aes(model_outcome)) +
+    p <- ggplot(dat, aes(model_outcome)) +
       geom_bar() +
       stat_count(geom="text", aes_string(label="..count..", vjust=-0.5)) +
       xlab(outcome_string)
 } else {
-    ggplot(dat, aes(model_outcome)) +
+    p <- ggplot(dat, aes(model_outcome)) +
       geom_histogram() +
       xlab(outcome_string)
-
 }
+print(p)
 ```
 
 ```{r covariate-distribution-plot}

--- a/TopmedPipeline/inst/rmd/null_model_report.Rmd
+++ b/TopmedPipeline/inst/rmd/null_model_report.Rmd
@@ -34,10 +34,6 @@ COLOR_ZERO_LINE = "grey60"
 n_categories_boxplot = as.numeric(params$n_categories_boxplot)
 ```
 
-```{r, results = 'asis'}
-print(n_categories_boxplot)
-```
-
 ```{r}
 files <- list.files(pattern=".+params$")
 scripts <- sapply(files, function(x) {

--- a/TopmedPipeline/inst/rmd/null_model_report.Rmd
+++ b/TopmedPipeline/inst/rmd/null_model_report.Rmd
@@ -92,6 +92,7 @@ for(i in 1:g){
 dat$group <- group
 dat <- left_join(dat, annot, by = "sample.id")
 
+dat$outcome_numeric <- dat[[outcome]]
 if (is_binary) {
   dat[[outcome]] <- as.factor(dat[[outcome]])
   dat$model_outcome <- as.factor(dat$model_outcome)
@@ -226,8 +227,9 @@ cat(text)
 ```{r residual-plots, results = "asis"}
 for (x in covars) {
     cat(sprintf("\n\n### %s {.unlisted .unnumbered}\n\n", x))
-    p_out <- ggplot(dat, aes_string(x = x, y = "model_outcome")) +
-      ggtitle(outcome_string)
+    p_out <- ggplot(dat, aes_string(x = x, y = "outcome_numeric")) +
+      ggtitle(outcome_string) +
+      ylab(outcome_string)
     p_res <- ggplot(dat, aes_string(x = x, y = "resid.marginal")) +
       ggtitle(sprintf("%s - residuals", outcome_string))
     if (is.numeric(annot[[x]] )) {

--- a/TopmedPipeline/inst/rmd/null_model_report.Rmd
+++ b/TopmedPipeline/inst/rmd/null_model_report.Rmd
@@ -64,9 +64,9 @@ outcome_string <- modelOutcomeString(outcome, inverse_normal = is_invnorm)
 ```
 
 ```{r prepare-data}
-# Fix 0/1 covariates so they display as categorical.
+# Display any covariate with < 10 values using boxplots instead of scatterplots.
 for (covar in covars) {
-  if (!is.numeric(annot[[covar]]) | length(setdiff(annot[[covar]], c(0, 1, NA))) == 0) {
+  if (!is.numeric(annot[[covar]]) || length(unique(annot[[covar]])) < 10) {
     annot[[covar]] <- as.factor(annot[[covar]])
   }
 }


### PR DESCRIPTION
Various updates to the null model report:
* Plot linear covariates using boxplots when there are a small number of categories. Add a new config parameter in `null_model_report.R` that allows the user to control this threshold.
* Add plots of covariates vs. outcome
* Rotate x-axis labels on boxplot to reduce overlap with long axis labels

For now the null null model parameter for plotting linear covariates as boxplots vs. scatterplots is named `n_categories_boxplot`. I don't think this is a great name so let me know if you have suggestions for a better parameter name. Some other ideas are `linear_boxplot_threshold` or `covar_boxplot_threshold`?