### PR TITLE
Allow simple data.frame

### DIFF
--- a/R/find_unrelated.R
+++ b/R/find_unrelated.R
@@ -53,8 +53,11 @@ if (!is.na(config["study"]) & !is.na(config["phenotype_file"])) {
     
     study <- config["study"]
     annot <- getobj(config["phenotype_file"])
-    stopifnot(study %in% varLabels(annot))
-    annot <- pData(annot)[,c("sample.id", study)]
+    if (is(annot, "AnnotatedDataFrame")) {
+        annot <- pData(annot)
+    }
+    stopifnot(study %in% names(annot))
+    annot <- annot[,c("sample.id", study)]
     names(annot)[2] <- "study"
     if (!is.null(sample.id)) {
         annot <- annot[annot$sample.id %in% sample.id,]

--- a/R/kinship_plots.R
+++ b/R/kinship_plots.R
@@ -103,9 +103,11 @@ if (!is.na(config["phenotype_file"]) & !is.na(config["study"])) {
     message("Plotting by study variable ", study)
 
     annot <- getobj(config["phenotype_file"])
-    stopifnot(study %in% varLabels(annot))
-    annot <- pData(annot) %>%
-        select_("sample.id", study)
+    if (is(annot, "AnnotatedDataFrame")) {
+        annot <- pData(annot)
+    }
+    stopifnot(study %in% names(annot))
+    annot <- select_(annot, "sample.id", study)
 
     kinship <- kinship %>%
         left_join(annot, by=c(ID1="sample.id")) %>%

--- a/R/pca_plots.R
+++ b/R/pca_plots.R
@@ -43,9 +43,11 @@ ggsave(config["out_file_scree"], plot=p, width=6, height=6)
 if (!is.na(config["phenotype_file"]) & !is.na(config["group"])) {
     group <- config["group"]
     annot <- getobj(config["phenotype_file"])
-    stopifnot(group %in% varLabels(annot))
-    annot <- pData(annot) %>%
-        select_("sample.id", group)
+    if (is(annot, "AnnotatedDataFrame")) {
+        annot <- pData(annot)
+    }
+    stopifnot(group %in% names(annot))
+    annot <- select_(annot, "sample.id", group)
     pcs <- left_join(pcs, annot, by="sample.id")
 } else {
     ## make up dummy group

--- a/R/pedigree_check.R
+++ b/R/pedigree_check.R
@@ -26,7 +26,10 @@ config <- setConfigDefaults(config, required, optional)
 print(config)
 
 annot <- getobj(config["phenotype_file"])
-annot <- pData(annot) %>%
+if (is(annot, "AnnotatedDataFrame")) {
+    annot <- pData(annot)
+}
+annot <- annot %>%
     select(sample.id, Individ=!!config["subjectID"])
 
 if (!is.na(config["sample_include_file"])) {

--- a/TopmedPipeline.py
+++ b/TopmedPipeline.py
@@ -2,7 +2,7 @@
 from __future__ import division
 """Utility functions for TOPMed pipeline"""
 
-__version__ = "2.8.2"
+__version__ = "2.9.0"
 
 import os
 import sys

--- a/TopmedPipeline/DESCRIPTION
+++ b/TopmedPipeline/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: TopmedPipeline
-Version: 2.8.1
+Version: 2.9.0
 Type: Package
 Title: Utilities for the TOPMed pipeline
 Description: Utilities for the TOPMed pipeline.

--- a/TopmedPipeline/R/getPhenotypes.R
+++ b/TopmedPipeline/R/getPhenotypes.R
@@ -42,7 +42,10 @@ getPhenotypes <- function(config) {
     group.var <- unname(config["group_var"])
     if (is.na(group.var)) group.var <- NULL
 
-    annot <- annot[,unique(c("sample.id", outcome, covars, group.var))]
+    ## keep sex in annot for allele calculations, even if not a covariate
+    keep.vars <- unique(c("sample.id", outcome, covars, group.var))
+    if ("sex" %in% varLabels(annot)) keep.vars <- unique(c(keep.vars, "sex"))
+    annot <- annot[,keep.vars]
 
     ## select samples
     if (!is.na(config["sample_include_file"])) {

--- a/TopmedPipeline/R/getPhenotypes.R
+++ b/TopmedPipeline/R/getPhenotypes.R
@@ -12,6 +12,10 @@ getPhenotypes <- function(config) {
 
     ## get phenotypes
     annot <- getobj(config["phenotype_file"])
+    if (!is(annot, "AnnotatedDataFrame")) {
+        annot <- AnnotatedDataFrame(annot)
+    }
+    stopifnot("sample.id" %in% varLabels(annot))
 
     ## get PCs
     n_pcs <- as.integer(config["n_pcs"])


### PR DESCRIPTION
Allow simple data.frames as input to pipeline scripts. `TopmedPipeline::getPhenotypes`will auto-convert to `AnnotatedDataFrame`, and check for a `sample.id` column. Plotting scripts will convert an `AnnotatedDataFrame` to a standard `data.frame` if necessary.