### PR TITLE
Add MAF and missingness filters to `pca_corr_vars.R`

### DIFF
--- a/R/pca_corr_vars.R
+++ b/R/pca_corr_vars.R
@@ -16,7 +16,9 @@ required <- c("gds_file",
               "segment_file")
 optional <- c("n_corr_vars"=10e6,
               "out_file"="pca_corr_variants.RData",
-              "variant_include_file"=NA)
+              "variant_include_file"=NA,
+              "corr_maf_threshold" = 0.01,
+              "corr_missing_threshold" = 0.05)
 config <- setConfigDefaults(config, required, optional)
 print(config)
 
@@ -36,6 +38,11 @@ gds <- seqOpen(gdsfile)
 
 filterByPass(gds)
 filterBySNV(gds)
+
+# Filter by MAF and missing rate
+seqSetFilterCond(gds,
+                 maf=as.numeric(config["corr_maf_threshold"]),
+                 missing.rate=as.numeric(config["corr_missing_threshold"]))
 
 vars <- seqGetData(gds, "variant.id")
 

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ The first step in evalulating relatedness and population structure is to select 
 	`thin` | `TRUE` | Logical for whether to thin points in the PC-variant correlation plots.
 	`phenotype_file` | `NA` | RData file with AnnotatedDataFrame of phenotypes. Used for color-coding PCA plots by group.
 	`group` | `NA` | Name of column in `phenotype_file` containing group variable.
-  `corr_maf_threshold` | 0.01 | MAF threshold for selecting variants when calculating PCA correlations.
-  `corr_missing_threshold` | 0.05 | Missingness threshold for selecting variants when calculating PCA correlations.
+	`corr_maf_threshold` | 0.01 | MAF threshold for selecting variants when calculating PCA correlations.
+	`corr_missing_threshold` | 0.05 | Missingness threshold for selecting variants when calculating PCA correlations.
 
 5. [PC-Relate](http://www.ncbi.nlm.nih.gov/pubmed/26748516) to estimate kinship coefficients adjusted for population structure and admixture using PCs
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ The first step in evalulating relatedness and population structure is to select 
 	`thin` | `TRUE` | Logical for whether to thin points in the PC-variant correlation plots.
 	`phenotype_file` | `NA` | RData file with AnnotatedDataFrame of phenotypes. Used for color-coding PCA plots by group.
 	`group` | `NA` | Name of column in `phenotype_file` containing group variable.
+  `corr_maf_threshold` | 0.01 | MAF threshold for selecting variants when calculating PCA correlations.
+  `corr_missing_threshold` | 0.05 | Missingness threshold for selecting variants when calculating PCA correlations.
 
 5. [PC-Relate](http://www.ncbi.nlm.nih.gov/pubmed/26748516) to estimate kinship coefficients adjusted for population structure and admixture using PCs
 


### PR DESCRIPTION
Add MAF and missingness filters to `pca_corr_vars.R` config parameters (`corr_maf_threshold` and `corr_missing_threshold`) with sensible defaults. Matt had seen some odd behavior in the PCA correlation plots and it turns out that all the variants had high missingness.