### PR TITLE
Genotype coding config parameter

### DIFF
--- a/R/assoc_single.R
+++ b/R/assoc_single.R
@@ -35,7 +35,8 @@ optional <- c("genome_build"="hg38",
               "segment_file"=NA,
               "test_type"="score",
               "variant_include_file"=NA,
-              "variant_block_size"=1024)
+              "variant_block_size"=1024,
+              "genotype_coding"="additive")
 config <- setConfigDefaults(config, required, optional)
 print(config)
 writeConfig(config, paste0(basename(argv$config), ".assoc_single.params"))
@@ -111,11 +112,14 @@ test <- switch(tolower(config["test_type"]),
                score.spa="Score.SPA",
                binomirare="BinomiRare")
 
-assoc <- assocTestSingle(iterator, nullModel, 
-                         test=test, 
-                         fast.score.SE=fast.score.SE, 
+geno.coding <- config["genotype_coding"]
+
+assoc <- assocTestSingle(iterator, nullModel,
+                         test=test,
+                         fast.score.SE=fast.score.SE,
                          genome.build=build,
-                         BPPARAM=BPPARAM)
+                         BPPARAM=BPPARAM,
+                         geno.coding=geno.coding)
 
 save(assoc, file=constructFilename(config["out_prefix"], chr, segment))
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ related (mixed model), options are `score` if `family` is `gaussian` or `poisson
 `known_hits_file` | `NA` | RData file with data.frame containing columns `chr` and `pos`. If provided, 1 Mb regions surrounding each variant listed will be omitted from the QQ and manhattan plots.
 `plot_maf_threshold` | NA | Minimum minor allele frequency for variants to include in plots. Ignored if `plot_mac_threshold` is specified.
 `qq_maf_bins` | NA | Space separated string of minor allele frequencies (e.g., `"0.01 0.05 0.1"`). If set, generate a QQ plot with binned by the specified minor allele frequencies. 0 and Infinity will automatically be added.
-`genotype_coding` | `additive` | String indicating how genotypes should be coded (`additive`, `recessive`, or `dominant`).
+`genotype_coding` | `additive` | String indicating how genotypes should be coded (`"additive"`, `"recessive"`, or `"dominant"`).
 
 ### Parameters common to aggregate and sliding window tests
 

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ related (mixed model), options are `score` if `family` is `gaussian` or `poisson
 `known_hits_file` | `NA` | RData file with data.frame containing columns `chr` and `pos`. If provided, 1 Mb regions surrounding each variant listed will be omitted from the QQ and manhattan plots.
 `plot_maf_threshold` | NA | Minimum minor allele frequency for variants to include in plots. Ignored if `plot_mac_threshold` is specified.
 `qq_maf_bins` | NA | Space separated string of minor allele frequencies (e.g., `"0.01 0.05 0.1"`). If set, generate a QQ plot with binned by the specified minor allele frequencies. 0 and Infinity will automatically be added.
-
+`genotype_coding` | `additive` | String indicating how genotypes should be coded (`additive`, `recessive`, or `dominant`).
 
 ### Parameters common to aggregate and sliding window tests
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ config parameter | default value | description
 `known_hits_file` | `NA` | RData file with data.frame containing columns `chr` and `pos`. If provided, 1 Mb regions surrounding each variant listed will be omitted from the QQ and manhattan plots.
 `plot_maf_threshold` | NA | Minimum minor allele frequency for variants to include in plots. Ignored if `plot_mac_threshold` is specified.
 `qq_maf_bins` | NA | Space separated string of minor allele frequencies (e.g., `"0.01 0.05 0.1"`). If set, generate a QQ plot with binned by the specified minor allele frequencies. 0 and Infinity will automatically be added.
-`genotype_coding` | `additive` | String indicating how genotypes should be coded (`"additive"`, `"recessive"`, or `"dominant"`).
+`genotype_coding` | `additive` | String indicating how genotypes should be coded (`additive`, `recessive`, or `dominant`).
 
 ### Parameters common to aggregate and sliding window tests
 

--- a/README.md
+++ b/README.md
@@ -303,8 +303,7 @@ config parameter | default value | description
 --- | --- | ---
 `mac_threshold` | `5` | Minimum minor allele count for variants to include in test. Use a higher threshold when outcome is binary.
 `maf_threshold` | `0.001` | Minimum minor allele frequency for variants to include in test. Only used if `mac_threshold` is `NA`.
-`test_type` | `score` | Type of test to perform. If samples are
-related (mixed model), options are `score` if `family` is `gaussian` or `poisson`, `score`, `score.spa`, and `binomirare` if `family` is `binomial`.
+`test_type` | `score` | Type of test to perform. If samples are related (mixed model), options are `score` if `family` is `gaussian` or `poisson`, `score`, `score.spa`, and `binomirare` if `family` is `binomial`.
 `conditional_variant_file` | `NA` | RData file with data frame of of conditional variants. Columns should include `chromosome` (or `chr`) and `variant.id`. If provided, these variants will be omitted from the association test output.
 `known_hits_file` | `NA` | RData file with data.frame containing columns `chr` and `pos`. If provided, 1 Mb regions surrounding each variant listed will be omitted from the QQ and manhattan plots.
 `plot_maf_threshold` | NA | Minimum minor allele frequency for variants to include in plots. Ignored if `plot_mac_threshold` is specified.

--- a/TopmedPipeline.py
+++ b/TopmedPipeline.py
@@ -2,7 +2,7 @@
 from __future__ import division
 """Utility functions for TOPMed pipeline"""
 
-__version__ = "2.10.1"
+__version__ = "2.10.2"
 
 import os
 import sys

--- a/TopmedPipeline/DESCRIPTION
+++ b/TopmedPipeline/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: TopmedPipeline
-Version: 2.10.0
+Version: 2.10.1
 Type: Package
 Title: Utilities for the TOPMed pipeline
 Description: Utilities for the TOPMed pipeline.

--- a/TopmedPipeline/inst/rmd/analysis_report.Rmd
+++ b/TopmedPipeline/inst/rmd/analysis_report.Rmd
@@ -63,7 +63,7 @@ disp <- c("window_size", "window_step",
           "null_model_file")
 if (unit == "single") {
     if (!is.na(config["mac_threshold"])) disp <- c(disp, "mac_threshold") else disp <- c(disp, "maf_threshold")
-    disp <- c(disp, "test_type")
+    disp <- c(disp, "test_type", "genotype_coding")
 } else {
     disp <- c(disp, "weight_beta", "test")
     if (config["test"] == "burden") disp <- c(disp, "test_type") else disp <- c(disp, "pval_skat", "rho")

--- a/testdata/assoc_single_recessive.config
+++ b/testdata/assoc_single_recessive.config
@@ -1,0 +1,8 @@
+out_prefix "test"
+gds_file "testdata/1KG_phase3_subset_chr .gds"
+phenotype_file "testdata/1KG_phase3_subset_annot.RData"
+null_model_file "testdata/null_model.RData"
+variant_include_file "testdata/variant_include_chr .RData"
+mac_threshold 3
+genome_build "hg19"
+genotype_coding "recessive"


### PR DESCRIPTION
* Add a config parameter for genotype coding (`genotype_coding`).
* Update analysis_report to show this config parameter
* Update README
* Bump version numbers